### PR TITLE
 Fix `previewDocs` on Linux when using IntelliJ

### DIFF
--- a/src/main/java/org/moddedmc/wiki/toolkit/task/InstallDependenciesTask.java
+++ b/src/main/java/org/moddedmc/wiki/toolkit/task/InstallDependenciesTask.java
@@ -1,10 +1,17 @@
 package org.moddedmc.wiki.toolkit.task;
 
+import org.gradle.internal.os.OperatingSystem;
 import org.gradle.work.DisableCachingByDefault;
 
 @DisableCachingByDefault
 public abstract class InstallDependenciesTask extends ExecuteCommandTask {
     public InstallDependenciesTask() {
-        getCommand().addAll("npm", "install");
+        if (OperatingSystem.current().isLinux()) {
+            getCommand().addAll("bash", "-ci", "npm install");
+        } else if (OperatingSystem.current().isMacOsX()) {
+            getCommand().addAll("bash", "-c", "npm install");
+        } else {
+            getCommand().addAll("npm", "install");
+        }
     }
 }

--- a/src/main/java/org/moddedmc/wiki/toolkit/task/RunLocalWikiInstanceTask.java
+++ b/src/main/java/org/moddedmc/wiki/toolkit/task/RunLocalWikiInstanceTask.java
@@ -20,8 +20,7 @@ public abstract class RunLocalWikiInstanceTask extends ExecuteCommandTask {
     public RunLocalWikiInstanceTask() {
         if (OperatingSystem.current().isLinux()) {
             getCommand().addAll("bash", "-ci", "npm run dev");
-        }
-        else if (OperatingSystem.current().isMacOsX()) {
+        } else if (OperatingSystem.current().isMacOsX()) {
             getCommand().addAll("bash", "-c", "npm run dev");
         } else {
             getCommand().addAll("npm", "run", "dev");

--- a/src/main/java/org/moddedmc/wiki/toolkit/task/RunLocalWikiInstanceTask.java
+++ b/src/main/java/org/moddedmc/wiki/toolkit/task/RunLocalWikiInstanceTask.java
@@ -18,7 +18,10 @@ public abstract class RunLocalWikiInstanceTask extends ExecuteCommandTask {
     public abstract SetProperty<DocumentationRoot> getDocumentationRoots();
 
     public RunLocalWikiInstanceTask() {
-        if (OperatingSystem.current() != OperatingSystem.WINDOWS) {
+        if (OperatingSystem.current().isLinux()) {
+            getCommand().addAll("bash", "-ci", "npm run dev");
+        }
+        else if (OperatingSystem.current().isMacOsX()) {
             getCommand().addAll("bash", "-c", "npm run dev");
         } else {
             getCommand().addAll("npm", "run", "dev");


### PR DESCRIPTION
Currently, when `previewDocs` is run through IntelliJ on Linux, it does not inherit custom paths from `.bashrc`. This becomes important when dealing with Node, which when installed through its `nvm` installer is not installed on the default path. This patch, based off [this article](https://web.archive.org/web/20211028144731/http://taming-the-bits.logdown.com/posts/275357-how-to-improve-the-terminal-window-in-idea), makes bash interactive, and fixes the path issues.

I've intentionally opted to leave macOS alone, as I'm not aware enough of how its version of bash differs to know if this patch is required.

I'm hoping this also fixes #2, but I've switched to a `.deb` version of IntelliJ at this point and haven't tested it.